### PR TITLE
feat: add instructions and readme

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,39 @@
+# Copilot Instructions for Nitrogen
+
+## Project Overview
+
+## Architectural Pattern: N-Tier
+- This template proposes an **N-Tier Architecture** with clear separation of concerns:
+	- **Repository**: Handles direct database access and queries (see `server/database/`).
+	- **Services**: Encapsulates business logic, typically implemented in dedicated service files (not shown in starter, but recommended for complex logic).
+	- **Controller**: Manages HTTP request/response, mapped to files under the `api` folder. There is no dedicated `controller` folder; instead, each file in `api` (e.g., `api/users/[id].get.ts`, `api/users/[id].put.ts`) acts as a controller for its route.
+
+
+- **Config**: `nitro.config.ts` sets up Nitro with `srcDir: 'server'` and disables auto-imports.
+
+## Developer Workflows
+- **Install dependencies**: `pnpm install --frozen-lockfile`
+- **Build**: `pnpm build` (runs `nitro build`)
+- **Dev server**: `pnpm dev` (runs `nitro dev`)
+- **Lint**: `pnpm lint` (uses `oxlint` with custom flags)
+- **Format**: `pnpm format` (formats all TS files with Prettier)
+- **Database**: Use Drizzle Kit scripts (`pnpm db:generate`, `pnpm db:push`, `pnpm db:pull`, `pnpm db:studio`, `pnpm db:check`)
+- **CI**: See `.github/workflows/ci.yaml` for build/lint steps on PRs and pushes to `main`.
+
+## Patterns & Conventions
+- **Environment Variables**: All DB config is loaded from `.env` and validated with `zod`.
+- **TypeScript Paths**: Use `~/*` for `server/*` and `@/*` for project root (see `tsconfig.json`).
+- **Health Checks**: `server/routes/health/ready.get.ts` tests DB connection; `server/routes/health/index.get.ts` reports uptime/memory.
+- **Strict TypeScript**: `tsconfig.json` enforces strictness and disables unused locals.
+- **Snake_case DB**: Drizzle config enforces snake_case for DB schema/migrations.
+
+## Integration Points
+- **PostgreSQL**: All DB access via Drizzle ORM and `pg`.
+- **Nitro**: Handles routing, serverless deployment, and build.
+- **Oxlint**: Used for linting with custom correctness flags.
+
+## Examples
+- To add a new route: create a `.get.ts` or `.post.ts` file in `server/routes/` and export an `eventHandler`.
+- To add a DB migration: update schema in `server/database/schemas/`, then run `pnpm db:generate`.
+
+---

--- a/README.md
+++ b/README.md
@@ -1,3 +1,52 @@
-# Nitro starter
+# Nitrogen Starter Template
 
-Look at the [nitro quick start](https://nitro.build/guide#quick-start) to learn more how to get started.
+**Quick Start:**
+
+```sh
+pnpm dlx gitget xcvzmoon/nitrogen
+```
+
+---
+
+Nitrogen is a starter template for building serverless backends with [Nitro](https://nitro.build/), TypeScript, and Drizzle ORM (PostgreSQL).
+
+## Features
+
+- N-Tier Architecture: Repository, Services, Controller (controllers are mapped to files in the `api` folder)
+- TypeScript strictness and path aliases
+- Drizzle ORM for migrations and schema
+- Health check endpoints
+- Pre-configured linting and formatting
+- CI workflow for build/lint
+
+## Directory Structure
+
+- `server/` — Main backend code
+  - `api/` — Route controllers (each file is a controller for its route)
+  - `routes/` — HTTP endpoints
+  - `database/` — DB connection and ORM
+  - `config/` — Environment/config validation
+
+## Developer Workflows
+
+- Install dependencies: `pnpm install --frozen-lockfile`
+- Build: `pnpm build`
+- Dev server: `pnpm dev`
+- Lint: `pnpm lint`
+- Format: `pnpm format`
+- Database: `pnpm db:generate`, `pnpm db:push`, `pnpm db:pull`, `pnpm db:studio`, `pnpm db:check`
+
+## Health Checks
+
+- `server/routes/health/ready.get.ts` — DB connection
+- `server/routes/health/index.get.ts` — Uptime/memory
+
+## Conventions
+
+- Environment config via `.env` and `zod`
+- Snake_case enforced for DB schema/migrations
+- All DB access via Drizzle ORM and `pg`
+
+---
+
+See `.github/copilot-instructions.md` for AI agent guidance and architectural details.


### PR DESCRIPTION
This pull request adds comprehensive documentation and onboarding instructions for the Nitrogen starter template, clarifying its architecture, developer workflows, and conventions. The main changes include a new Copilot instructions file and a rewritten `README.md` to help developers understand project structure and best practices.

**Documentation improvements:**

* Added `.github/copilot-instructions.md` to provide an overview of Nitrogen’s N-Tier architecture, developer workflows, conventions, integration points, and examples for extending the project.
* Rewrote `README.md` to include a quick start guide, feature list, directory structure, workflow commands, health check endpoints, and conventions, making it easier for new contributors to get started and understand the project's organization.

**Developer guidance:**

* Both files now clearly describe how to add new routes and migrations, and where to find configuration and health check endpoints. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R1-R39) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R52)
* The documentation emphasizes strict TypeScript usage, path aliases, and snake_case conventions for database schemas. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R1-R39) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R52)

**Integration and CI details:**

* Added information about integration points (PostgreSQL, Drizzle ORM, Nitro, Oxlint) and CI workflows for linting and building on PRs and pushes to `main`.

These changes make the onboarding process smoother and ensure architectural consistency for future development.